### PR TITLE
updated urls for https and changed links

### DIFF
--- a/QuandlCS/Helpers/Constants.cs
+++ b/QuandlCS/Helpers/Constants.cs
@@ -10,10 +10,10 @@ namespace QuandlCS.Helpers
   {
     #region Addresses 
 
-    internal const string APIMultisetsAddress      = "http://www.quandl.com/api/v1/multisets";
-    internal const string APIDatasetsAddress       = "http://www.quandl.com/api/v1/datasets";
-    internal const string APIDatasetsImportAddress = "http://www.quandl.com/api/v1/datasets/import";
-    internal const string APIFavouritesAddress     = "http://www.quandl.com/api/v1/current_user/collections/datasets/favourites";
+    internal const string APIMultisetsAddress      = "https://www.quandl.com/api/v1/multisets";
+    internal const string APIDatasetsAddress       = "https://www.quandl.com/api/v1/datasets";
+    internal const string APIDatasetsImportAddress = "https://www.quandl.com/api/v1/datasets/import";
+    internal const string APIFavouritesAddress     = "https://www.quandl.com/api/v1/current_user/collections/datasets/favourites";
 
     #endregion
 

--- a/QuandlCS/Types/FileFormats.cs
+++ b/QuandlCS/Types/FileFormats.cs
@@ -6,7 +6,7 @@ namespace QuandlCS.Types
   /// should be returned in. 
   /// 
   /// More information about file formats can be found at:
-  /// http://www.quandl.com/help/api#Download
+  /// https://www.quandl.com/help/api#Data-Formats
   /// </summary>
   public enum FileFormats
   {

--- a/QuandlCS/Types/Frequencies.cs
+++ b/QuandlCS/Types/Frequencies.cs
@@ -6,7 +6,7 @@ namespace QuandlCS.Types
   /// request from Quandl.
   /// 
   /// More information about file formats can be found at:
-  /// http://www.quandl.com/help/api#Frequency+Collapsing
+  /// https://www.quandl.com/help/api#Data-Manipulation
   /// </summary>
   public enum Frequencies
   {

--- a/QuandlCS/Types/SortOrders.cs
+++ b/QuandlCS/Types/SortOrders.cs
@@ -6,7 +6,7 @@ namespace QuandlCS.Types
   /// being returned by Quandl.
   /// 
   /// More information about file formats can be found at:
-  /// http://www.quandl.com/help/api#Sort+Order
+  /// https://www.quandl.com/help/api#Data-Manipulation
   /// </summary>
   public enum SortOrders
   {

--- a/QuandlCS/Types/Transformations.cs
+++ b/QuandlCS/Types/Transformations.cs
@@ -6,7 +6,7 @@ namespace QuandlCS.Types
   /// returning the results of the request.
   /// 
   /// More information about transformations can be found at:
-  /// http://www.quandl.com/help/api#Transformations
+  /// https://www.quandl.com/help/api#Data-Manipulation
   /// </summary>
   public enum Transformations
   {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ QuandlCS is a simple wrapper around the Quandl API to provide easy access. The l
 
 Started as a project in an attempt at my colleagues [Project365](http://staticcast.wordpress.com/2013/12/28/programming-365/)  
 
-Visit the [online reference](http://www.quandl.com/help/api) for more information about the Quandl API.
+Visit the [online reference](https://www.quandl.com/help/api) for more information about the Quandl API.
 
 ### Tutorial
 The CS API is simple to use and provides type safety garuantees and basic validation on data before requesting. Interaction is based around the concept of a request with all download requests implementing a single interface. Once a request is created this can be used with the QuandlConnection object to download and return the data or to generate the request string URL (`www.quandl.com/api/v1/datasets/PRAGUESE/PX.json`) to handle manually. 
@@ -25,11 +25,11 @@ When used this class will validate that the source and code provided do not cont
 
 
 ###### FileFormats
-The FileFormats enum represents each of the available [output formats](http://www.quandl.com/help/api#Basic+Principles) from the Quandl API. Not all of the formats will be valid for each of the different requests. (e.g. Metadata requests are only available in XML and JSON formats... this is validated by the QuandlMetadataRequest class when used)
+The FileFormats enum represents each of the available [output formats](https://www.quandl.com/help/api#Data-Formats) from the Quandl API. Not all of the formats will be valid for each of the different requests. (e.g. Metadata requests are only available in XML and JSON formats... this is validated by the QuandlMetadataRequest class when used)
 
 
 ###### Frequencies
-The Frequencies enum is used to specify which [frequency collapse](http://www.quandl.com/help/api#Frequency+Collapsing) is required for the dataset being downloaded.
+The Frequencies enum is used to specify which [frequency collapse](https://www.quandl.com/help/api#Data-Manipulation) is required for the dataset being downloaded.
 
 
 ###### SortOrders
@@ -37,7 +37,7 @@ The SortOrders enum, as you can probably imagine, specified if the data should b
 
 
 ###### Transformations
-The Transformations enum specifies which [transformation](http://www.quandl.com/help/api#Transformations) should be applied to the before downloading. 
+The Transformations enum specifies which [transformation](https://www.quandl.com/help/api#Data-Manipulation) should be applied to the before downloading. 
 
 
 #### Download


### PR DESCRIPTION
Main change:  http API requests are not https
secondary changes:  links to some of the help pages have been updated